### PR TITLE
Allows to remove all queries for a URI

### DIFF
--- a/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
+++ b/http4k-core/src/main/kotlin/org/http4k/core/Uri.kt
@@ -64,7 +64,7 @@ data class Uri(val scheme: String, val userInfo: String, val host: String, val p
 
 fun Uri.removeQuery(name: String) = copy(query = query.toParameters().filterNot { it.first == name }.toUrlFormEncoded())
 
-fun Uri.removeQueries(prefix: String) =
+fun Uri.removeQueries(prefix: String = "") =
     copy(query = query.toParameters().filterNot { it.first.startsWith(prefix) }.toUrlFormEncoded())
 
 fun Uri.query(name: String, value: String?): Uri =


### PR DESCRIPTION
The `Request` already allows to remove all queries as it has the default parameter value set as "". This adds also the default to `Uri.removeQueries()` so it can remove all queries as well.